### PR TITLE
#14 Adicionar fluxo para retornar informações da Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@
 ## Docker
 
 ![Docker Desktop executanto Banco de Dados!](/assets/images/docker-desktop.png 'Docker Desktop executanto Banco de Dados') _"Docker Desktop executanto Banco de Dados"_
+
+## Rotas HTTP
+
+### Role
+
+- `GET` Find All Roles `/role`

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,4 +3,11 @@ import fastify from 'fastify';
 
 import '@/lib/typeorm/typeorm';
 
+// Imported routes
+import { roleRoutes } from './http/controllers/role/routes';
+
+// Export Fastify App instance
 export const app = fastify();
+
+// Registered routes
+app.register(roleRoutes);

--- a/src/http/controllers/role/find-all-roles.ts
+++ b/src/http/controllers/role/find-all-roles.ts
@@ -1,0 +1,12 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+import { MakeFindAllRolesUseCase } from '@/use-cases/factories/make-find-all-roles';
+
+export async function findAllRoles(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const findAllRolesUseCase = MakeFindAllRolesUseCase();
+  const roles = await findAllRolesUseCase.handler();
+  return reply.status(200).send(roles);
+}

--- a/src/http/controllers/role/routes.ts
+++ b/src/http/controllers/role/routes.ts
@@ -1,0 +1,7 @@
+import { FastifyInstance } from 'fastify';
+
+import { findAllRoles } from './find-all-roles';
+
+export async function roleRoutes(app: FastifyInstance) {
+  app.get('/role', findAllRoles);
+}

--- a/src/repositories/role.repository.interface.ts
+++ b/src/repositories/role.repository.interface.ts
@@ -1,0 +1,5 @@
+import { IRole } from '@/entities/models/role.interface';
+
+export interface IRoleRepository {
+  findAll(): Promise<IRole[]>;
+}

--- a/src/repositories/typeorm/role.repository.ts
+++ b/src/repositories/typeorm/role.repository.ts
@@ -1,0 +1,18 @@
+import { Repository } from 'typeorm';
+
+import { IRole } from '@/entities/models/role.interface';
+import { Role } from '@/entities/role.entity';
+import { appDataSource } from '@/lib/typeorm/typeorm';
+import { IRoleRepository } from '../role.repository.interface';
+
+export class RoleRepository implements IRoleRepository {
+  private repository: Repository<Role>;
+
+  constructor() {
+    this.repository = appDataSource.getRepository(Role);
+  }
+
+  async findAll(): Promise<IRole[]> {
+    return this.repository.find();
+  }
+}

--- a/src/use-cases/factories/make-find-all-roles.ts
+++ b/src/use-cases/factories/make-find-all-roles.ts
@@ -1,0 +1,8 @@
+import { RoleRepository } from '@/repositories/typeorm/role.repository';
+import { FindAllRolesUseCases } from '../find-all-roles';
+
+export function MakeFindAllRolesUseCase() {
+  const roleRepository = new RoleRepository();
+  const findAllRolesUseCase = new FindAllRolesUseCases(roleRepository);
+  return findAllRolesUseCase;
+}

--- a/src/use-cases/find-all-roles.ts
+++ b/src/use-cases/find-all-roles.ts
@@ -1,0 +1,10 @@
+import { IRole } from '@/entities/models/role.interface';
+import { IRoleRepository } from '@/repositories/role.repository.interface';
+
+export class FindAllRolesUseCases {
+  constructor(private roleRepository: IRoleRepository) {}
+
+  async handler(): Promise<IRole[]> {
+    return this.roleRepository.findAll();
+  }
+}


### PR DESCRIPTION
# Description

Adicionar fluxo para retornar informações das Roles
- Retornar as opções de Roles cadastradas no banco de dados é necessário para podermos usar na criação de Usuários.

# How Has This Been Tested?
METHOD: `GET`
URL: `localhost:3000/role`

# Screenshots
<img width="979" height="447" alt="Screenshot 2025-07-25 at 16 04 29" src="https://github.com/user-attachments/assets/ed22a846-9fcd-488b-a429-2ad431e8617b" />

<img width="959" height="189" alt="Screenshot 2025-07-25 at 16 04 52" src="https://github.com/user-attachments/assets/28876999-eb77-4226-b7fe-55b715f42d0c" />


Closes #14 